### PR TITLE
set video type for event-items

### DIFF
--- a/default.py
+++ b/default.py
@@ -261,6 +261,7 @@ def getevent():
                             li = xbmcgui.ListItem(eventVideo['title'], iconImage='https://www.telekomsport.de' + eventVideo['images']['editorial'])
                             li.setProperty('fanart_image', 'https://www.telekomsport.de' + eventVideo['images']['editorial'])
                             li.setProperty('IsPlayable', 'true')
+                            li.setInfo('video', {})
                             xbmcplugin.addDirectoryItem(handle=_addon_handler, url=url, listitem=li)
             xbmcplugin.endOfDirectory(_addon_handler)
 


### PR DESCRIPTION
maybe there should be some valid info in the dict, but with this video-info I can play the items `Gamereport` and `Wiederholung`